### PR TITLE
Fix pagination not resetting if using filter

### DIFF
--- a/frontend/src/components/MovieSection.tsx
+++ b/frontend/src/components/MovieSection.tsx
@@ -1,4 +1,11 @@
-import { Accessor, type Component, createEffect, For, on, Show } from "solid-js";
+import {
+  Accessor,
+  type Component,
+  createEffect,
+  For,
+  on,
+  Show,
+} from "solid-js";
 import MovieCard from "@/components/MovieCard";
 import type { Movie } from "@/types";
 import { usePagination } from "@/hooks/usePagination";
@@ -33,9 +40,9 @@ const MovieSection: Component<MovieSectionProps> = (props) => {
       () => props.movies().length,
       () => {
         reset();
-      }
-    )
-  )
+      },
+    ),
+  );
 
   return (
     <section class="movie-section">

--- a/frontend/src/components/MovieSection.tsx
+++ b/frontend/src/components/MovieSection.tsx
@@ -1,4 +1,4 @@
-import { Accessor, type Component, For, Show } from "solid-js";
+import { Accessor, type Component, createEffect, For, on, Show } from "solid-js";
 import MovieCard from "@/components/MovieCard";
 import type { Movie } from "@/types";
 import { usePagination } from "@/hooks/usePagination";
@@ -22,10 +22,20 @@ const MovieSection: Component<MovieSectionProps> = (props) => {
     goToPage,
     nextPage,
     previousPage,
+    reset,
   } = usePagination<Movie>(props.movies, itemsPerPage());
 
   const gridClass = () =>
     `movie-list${props.viewType === "grid" ? " movie-grid" : ""}`;
+
+  createEffect(
+    on(
+      () => props.movies().length,
+      () => {
+        reset();
+      }
+    )
+  )
 
   return (
     <section class="movie-section">


### PR DESCRIPTION
If pagination was set to a page different than the first page and you applied any filter, sometimes it would cause to no show any movies even though the movies().count was greater than 0