### PR TITLE
Refactor Movie Status to support more than 2 options

### DIFF
--- a/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
+++ b/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
@@ -1,0 +1,77 @@
+"""convert_watched_to_status
+
+Revision ID: c3p0e7f2a1d8
+Revises: b2c9999537da
+Create Date: 2026-02-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3p0e7f2a1d8'
+down_revision: Union[str, Sequence[str], None] = 'b2c9999537da'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: Add status column alongside watched (safe migration)."""
+    # Add new status column
+    op.execute("""
+        ALTER TABLE movies
+        ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'upcoming'
+    """)
+    
+    # Migrate existing data: Convert watched boolean to status string
+    op.execute("""
+        UPDATE movies
+        SET status = CASE
+            WHEN watched = TRUE THEN 'watched'
+            WHEN watched = FALSE THEN 'upcoming'
+            ELSE 'upcoming'
+        END
+        WHERE status = 'upcoming'
+    """)
+    
+    # Add constraint to ensure valid status values
+    op.execute("""
+        ALTER TABLE movies
+        ADD CONSTRAINT IF NOT EXISTS status_check CHECK (status IN ('watched', 'upcoming', 'streaming'))
+    """)
+    
+    # Create new index on status column
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_movies_status ON movies(status)
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema: Remove status column."""
+    op.execute("""
+        DROP INDEX IF EXISTS idx_movies_status
+    """)
+    
+    op.execute("""
+        ALTER TABLE movies
+        DROP CONSTRAINT IF EXISTS status_check
+    """)
+    
+    op.execute("""
+        ALTER TABLE movies
+        DROP COLUMN IF EXISTS status
+    """)
+
+    
+    # Drop status column
+    op.execute("""
+        ALTER TABLE movies
+        DROP COLUMN status
+    """)
+    
+    # Recreate old index
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_movies_watched ON movies(watched)
+    """)

--- a/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
+++ b/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
@@ -33,7 +33,6 @@ def upgrade() -> None:
             WHEN watched = FALSE THEN 'upcoming'
             ELSE 'upcoming'
         END
-        WHERE status = 'upcoming'
     """)
     
     # Add constraint to ensure valid status values

--- a/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
+++ b/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
@@ -38,8 +38,19 @@ def upgrade() -> None:
     
     # Add constraint to ensure valid status values
     op.execute("""
-        ALTER TABLE movies
-        ADD CONSTRAINT IF NOT EXISTS status_check CHECK (status IN ('watched', 'upcoming', 'streaming'))
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'status_check'
+                  AND conrelid = 'movies'::regclass
+            ) THEN
+                ALTER TABLE movies
+                ADD CONSTRAINT status_check CHECK (status IN ('watched', 'upcoming', 'streaming'));
+            END IF;
+        END
+        $$;
     """)
     
     # Create new index on status column

--- a/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
+++ b/alembic/versions/c3p0e7f2a1d8_convert_watched_to_status.py
@@ -63,13 +63,6 @@ def downgrade() -> None:
         ALTER TABLE movies
         DROP COLUMN IF EXISTS status
     """)
-
-    
-    # Drop status column
-    op.execute("""
-        ALTER TABLE movies
-        DROP COLUMN status
-    """)
     
     # Recreate old index
     op.execute("""

--- a/database/db.py
+++ b/database/db.py
@@ -25,6 +25,16 @@ def row_to_movie_dict(row: dict) -> dict:
     if row is None:
         return {}
 
+    # Get status from the row (from status column or convert from watched boolean for backwards compatibility)
+    status = row.get('status')
+    if not status:
+        # Fallback: convert watched boolean to status if status column doesn't exist yet
+        watched_value = row.get('watched')
+        if isinstance(watched_value, str):
+            status = watched_value
+        else:
+            status = 'watched' if bool(watched_value) else 'upcoming'
+
     movie = {
         'id': row.get('id'),
         'title': row.get('title') or '',
@@ -33,7 +43,7 @@ def row_to_movie_dict(row: dict) -> dict:
         'letterboxd_url': row.get('letterboxd_url') or '',
         'imdb_url': row.get('imdb_url') or '',
         'boobies': bool(row.get('boobies', False)),
-        'watched': bool(row.get('watched', False)),
+        'status': status,
         'image_link': row.get('image_link') or '',
         'rating': (str(row.get('rating')) if row.get('rating') is not None else ''),
         'votes': row.get('votes') or '',
@@ -67,7 +77,7 @@ def get_movies() -> dict:
                        m.letterboxd_url,
                        m.imdb_url,
                        m.boobies,
-                       m.watched,
+                       m.status,
                        m.image_link,
                        m.rating,
                        m.votes,
@@ -94,7 +104,15 @@ def add_movie(movie: dict) -> None:
         raise ValueError('Movie must have an id')
 
     boobies = bool(movie.get('boobies', False))
-    watched = bool(movie.get('watched', False))
+    
+    # Convert status to watched boolean for database (backwards compatible)
+    status = movie.get('status', movie.get('watched', 'upcoming'))
+    if isinstance(status, bool):
+        watched = status
+        status = 'watched' if status else 'upcoming'
+    else:
+        watched = status == 'watched'
+    
     rating = movie.get('rating')
     try:
         rating_val = float(rating) if (rating is not None and str(rating).strip() != '') else None
@@ -109,27 +127,53 @@ def add_movie(movie: dict) -> None:
             if cur.fetchone():
                 raise ValueError('Movie already exists')
 
-            cur.execute(
-                """
-                INSERT INTO movies (id, title, original_title, description, letterboxd_url, imdb_url, boobies, watched,
-                                    image_link, rating, votes, user_id)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                """,
-                (
-                    movie_id,
-                    movie.get('title'),
-                    movie.get('original_title'),
-                    movie.get('description'),
-                    movie.get('letterboxd_url'),
-                    movie.get('imdb_url'),
-                    boobies,
-                    watched,
-                    movie.get('image_link'),
-                    rating_val,
-                    movie.get('votes'),
-                    user_id,
+            # Try inserting with status column; fall back to watched column only
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO movies (id, title, original_title, description, letterboxd_url, imdb_url, boobies, watched,
+                                        status, image_link, rating, votes, user_id)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        movie_id,
+                        movie.get('title'),
+                        movie.get('original_title'),
+                        movie.get('description'),
+                        movie.get('letterboxd_url'),
+                        movie.get('imdb_url'),
+                        boobies,
+                        watched,
+                        status,
+                        movie.get('image_link'),
+                        rating_val,
+                        movie.get('votes'),
+                        user_id,
+                    )
                 )
-            )
+            except Exception:
+                # Fallback: insert without status column (for pre-migration databases)
+                cur.execute(
+                    """
+                    INSERT INTO movies (id, title, original_title, description, letterboxd_url, imdb_url, boobies, watched,
+                                        image_link, rating, votes, user_id)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        movie_id,
+                        movie.get('title'),
+                        movie.get('original_title'),
+                        movie.get('description'),
+                        movie.get('letterboxd_url'),
+                        movie.get('imdb_url'),
+                        boobies,
+                        watched,
+                        movie.get('image_link'),
+                        rating_val,
+                        movie.get('votes'),
+                        user_id,
+                    )
+                )
             conn.commit()
 
 
@@ -146,45 +190,91 @@ def save_movies(data: dict) -> None:
                 if not movie_id:
                     continue
                 boobies = bool(movie.get('boobies', False))
-                watched = bool(movie.get('watched', False))
+                
+                # Convert status to watched boolean for database (backwards compatible)
+                status = movie.get('status', movie.get('watched', 'upcoming'))
+                if isinstance(status, bool):
+                    watched = status
+                    status = 'watched' if status else 'upcoming'
+                else:
+                    watched = status == 'watched'
+                
                 rating = movie.get('rating')
                 try:
                     rating_val = float(rating) if (rating is not None and str(rating).strip() != '') else None
                 except Exception:
                     rating_val = None
 
-                cur.execute(
-                    """
-                    INSERT INTO movies (id, title, original_title, description, letterboxd_url, imdb_url, boobies,
-                                        watched, image_link, rating, votes, user_id)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (id) DO UPDATE SET title          = EXCLUDED.title,
-                                                   original_title = EXCLUDED.original_title,
-                                                   description    = EXCLUDED.description,
-                                                   letterboxd_url = EXCLUDED.letterboxd_url,
-                                                   imdb_url       = EXCLUDED.imdb_url,
-                                                   boobies        = EXCLUDED.boobies,
-                                                   watched        = EXCLUDED.watched,
-                                                   image_link     = EXCLUDED.image_link,
-                                                   rating         = EXCLUDED.rating,
-                                                   votes          = EXCLUDED.votes,
-                                                   user_id        = EXCLUDED.user_id
-                    """,
-                    (
-                        movie_id,
-                        movie.get('title'),
-                        movie.get('original_title'),
-                        movie.get('description'),
-                        movie.get('letterboxd_url'),
-                        movie.get('imdb_url'),
-                        boobies,
-                        watched,
-                        movie.get('image_link'),
-                        rating_val,
-                        movie.get('votes'),
-                        movie.get('user_id'),
+                # Try inserting with status column; fall back to without if it doesn't exist
+                try:
+                    cur.execute(
+                        """
+                        INSERT INTO movies (id, title, original_title, description, letterboxd_url, imdb_url, boobies,
+                                            watched, status, image_link, rating, votes, user_id)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (id) DO UPDATE SET title          = EXCLUDED.title,
+                                                       original_title = EXCLUDED.original_title,
+                                                       description    = EXCLUDED.description,
+                                                       letterboxd_url = EXCLUDED.letterboxd_url,
+                                                       imdb_url       = EXCLUDED.imdb_url,
+                                                       boobies        = EXCLUDED.boobies,
+                                                       watched        = EXCLUDED.watched,
+                                                       status         = EXCLUDED.status,
+                                                       image_link     = EXCLUDED.image_link,
+                                                       rating         = EXCLUDED.rating,
+                                                       votes          = EXCLUDED.votes,
+                                                       user_id        = EXCLUDED.user_id
+                        """,
+                        (
+                            movie_id,
+                            movie.get('title'),
+                            movie.get('original_title'),
+                            movie.get('description'),
+                            movie.get('letterboxd_url'),
+                            movie.get('imdb_url'),
+                            boobies,
+                            watched,
+                            status,
+                            movie.get('image_link'),
+                            rating_val,
+                            movie.get('votes'),
+                            movie.get('user_id'),
+                        )
                     )
-                )
+                except Exception:
+                    # Fallback: insert without status column (for pre-migration databases)
+                    cur.execute(
+                        """
+                        INSERT INTO movies (id, title, original_title, description, letterboxd_url, imdb_url, boobies,
+                                            watched, image_link, rating, votes, user_id)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (id) DO UPDATE SET title          = EXCLUDED.title,
+                                                       original_title = EXCLUDED.original_title,
+                                                       description    = EXCLUDED.description,
+                                                       letterboxd_url = EXCLUDED.letterboxd_url,
+                                                       imdb_url       = EXCLUDED.imdb_url,
+                                                       boobies        = EXCLUDED.boobies,
+                                                       watched        = EXCLUDED.watched,
+                                                       image_link     = EXCLUDED.image_link,
+                                                       rating         = EXCLUDED.rating,
+                                                       votes          = EXCLUDED.votes,
+                                                       user_id        = EXCLUDED.user_id
+                        """,
+                        (
+                            movie_id,
+                            movie.get('title'),
+                            movie.get('original_title'),
+                            movie.get('description'),
+                            movie.get('letterboxd_url'),
+                            movie.get('imdb_url'),
+                            boobies,
+                            watched,
+                            movie.get('image_link'),
+                            rating_val,
+                            movie.get('votes'),
+                            movie.get('user_id'),
+                        )
+                    )
             conn.commit()
 
 
@@ -244,18 +334,31 @@ def get_user_by_mail(mail: str) -> dict | None:
 def get_movie_by_id(movie_id: str) -> dict | None:
     """Return a single movie row (raw DB fields) or None if not found.
 
-    Returns a dict with at least 'id', 'user_id', and 'watched' keys when present.
+    Returns a dict with at least 'id', 'user_id', and 'status' keys when present.
+    Falls back to 'watched' column if 'status' doesn't exist yet (for backwards compatibility).
     """
     with psycopg.connect(DB_URL, row_factory=dict_row) as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT id, user_id, watched
-                FROM movies
-                WHERE id = %s
-                """,
-                (movie_id,)
-            )
+            # Try to select status column first; fall back to watched for backwards compatibility
+            try:
+                cur.execute(
+                    """
+                    SELECT id, user_id, status
+                    FROM movies
+                    WHERE id = %s
+                    """,
+                    (movie_id,)
+                )
+            except Exception:
+                # Fallback if status column doesn't exist yet
+                cur.execute(
+                    """
+                    SELECT id, user_id, watched as status
+                    FROM movies
+                    WHERE id = %s
+                    """,
+                    (movie_id,)
+                )
             row = cur.fetchone()
             return row if row else None
 
@@ -270,19 +373,54 @@ def delete_movie(movie_id: str) -> bool:
             return bool(res)
 
 
-def toggle_movie_watched(movie_id: str) -> bool | None:
-    """Toggle the watched flag for a movie and return the new watched value (True/False).
-
+def toggle_movie_status(movie_id: str) -> str | None:
+    """Cycle the status for a movie through the available statuses and return the new status value.
+    
+    Cycles: upcoming -> streaming -> watched -> upcoming
     Returns None if the movie was not found.
     """
     with psycopg.connect(DB_URL, row_factory=dict_row) as conn:
         with conn.cursor() as cur:
-            cur.execute('UPDATE movies SET watched = NOT watched WHERE id = %s RETURNING watched', (movie_id,))
-            row = cur.fetchone()
+            # Get current status
+            try:
+                cur.execute('SELECT status FROM movies WHERE id = %s', (movie_id,))
+                row = cur.fetchone()
+                if not row:
+                    return None
+                
+                current_status = row.get('status', 'upcoming')
+            except Exception:
+                # Fallback if status column doesn't exist yet
+                cur.execute('SELECT watched FROM movies WHERE id = %s', (movie_id,))
+                row = cur.fetchone()
+                if not row:
+                    return None
+                current_status = 'watched' if bool(row.get('watched')) else 'upcoming'
+            
+            # Cycle through statuses: upcoming -> streaming -> watched -> upcoming
+            if current_status == 'upcoming':
+                new_status = 'streaming'
+            elif current_status == 'streaming':
+                new_status = 'watched'
+            else:  # watched or any other value
+                new_status = 'upcoming'
+            
+            # Update status column
+            try:
+                cur.execute(
+                    'UPDATE movies SET status = %s WHERE id = %s RETURNING status',
+                    (new_status, movie_id)
+                )
+            except Exception:
+                # Fallback: update watched column for backwards compatibility
+                new_watched = new_status == 'watched'
+                cur.execute(
+                    'UPDATE movies SET watched = %s WHERE id = %s RETURNING watched',
+                    (new_watched, movie_id)
+                )
+            
             conn.commit()
-            if not row:
-                return None
-            return bool(row.get('watched'))
+            return new_status
 
 
 def toggle_movie_boobies(movie_id: str) -> bool | None:

--- a/database/db.py
+++ b/database/db.py
@@ -30,10 +30,7 @@ def row_to_movie_dict(row: dict) -> dict:
     if not status:
         # Fallback: convert watched boolean to status if status column doesn't exist yet
         watched_value = row.get('watched')
-        if isinstance(watched_value, str):
-            status = watched_value
-        else:
-            status = 'watched' if bool(watched_value) else 'upcoming'
+        status = 'watched' if bool(watched_value) else 'upcoming'
 
     movie = {
         'id': row.get('id'),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -176,7 +176,7 @@ const App = () => {
           <Show when={streamingMovies().length > 0}>
             <StreamingSection
               movies={streamingMovies}
-              viewType={viewType()}
+              // viewType={viewType()}
               onAction={fetchMovies}
             />
           </Show>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import movieStore, { fetchMovies, MovieStatus } from "@/hooks/movieStore";
 import authStore, { login, logout } from "@/hooks/authStore";
 import SortControls from "@/components/SortControls";
 import { makeComparator, SortField } from "@/utils/sort";
+import StreamingSection from "./components/StreamingSection";
 
 const App = () => {
   useMovieEvents();
@@ -173,12 +174,10 @@ const App = () => {
 
         <Show when={!movieStore.error}>
           <Show when={streamingMovies().length > 0}>
-            <MovieSection
-              title="Streaming"
+            <StreamingSection
               movies={streamingMovies}
               viewType={viewType()}
               onAction={fetchMovies}
-              itemsPerPage={maxItemsPerPage}
             />
           </Show>
           <Show when={showWatched()}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { UserFilter, UserFilterValue } from "@/components/UserFilter";
 import { NSFWFilter, NSFWFilterValue } from "@/components/NSFWFilter";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useMovieEvents } from "@/hooks/useMovieEvents";
-import movieStore, { fetchMovies } from "@/hooks/movieStore";
+import movieStore, { fetchMovies, MovieStatus } from "@/hooks/movieStore";
 import authStore, { login, logout } from "@/hooks/authStore";
 import SortControls from "@/components/SortControls";
 import { makeComparator, SortField } from "@/utils/sort";
@@ -84,12 +84,18 @@ const App = () => {
     return movies;
   });
 
+  const streamingMoviesRaw = createMemo(() =>
+    filteredMovies().filter((m) => m.status === MovieStatus.Streaming),
+  );
+
   const watchedMoviesRaw = createMemo(() =>
-    filteredMovies().filter((m) => m.watched),
+    filteredMovies().filter((m) => m.status === MovieStatus.Watched),
   );
   const upcomingMoviesRaw = createMemo(() =>
-    filteredMovies().filter((m) => !m.watched),
+    filteredMovies().filter((m) => m.status === MovieStatus.Upcoming),
   );
+
+  const streamingMovies = createMemo(() => streamingMoviesRaw());
 
   const watchedMovies = createMemo(() => {
     const arr = [...watchedMoviesRaw()];
@@ -166,6 +172,15 @@ const App = () => {
         </Show>
 
         <Show when={!movieStore.error}>
+          <Show when={streamingMovies().length > 0}>
+            <MovieSection
+              title="Streaming"
+              movies={streamingMovies}
+              viewType={viewType()}
+              onAction={fetchMovies}
+              itemsPerPage={maxItemsPerPage}
+            />
+          </Show>
           <Show when={showWatched()}>
             <MovieSection
               title="Watched"

--- a/frontend/src/components/MovieCard.tsx
+++ b/frontend/src/components/MovieCard.tsx
@@ -50,8 +50,7 @@ const MovieCard: Component<MovieCardProps> = (props) => {
     }
   };
 
-  const isUserAdmin = () =>
-    !!authStore.user && authStore.user.is_admin;
+  const isUserAdmin = () => !!authStore.user && authStore.user.is_admin;
 
   const canSetMovieStatus = (targetMovieStatus: MovieStatus): boolean =>
     isUserAdmin() && props.movie.status !== targetMovieStatus;
@@ -60,14 +59,20 @@ const MovieCard: Component<MovieCardProps> = (props) => {
     if (!authStore.user) return false;
     if (authStore.user.is_admin) return true;
 
-    return props.movie.user?.id === authStore.user.id && props.movie.status !== MovieStatus.Watched;
+    return (
+      props.movie.user?.id === authStore.user.id &&
+      props.movie.status !== MovieStatus.Watched
+    );
   };
 
   const canToggleBoobies = () => {
     if (!authStore.user) return false;
     if (authStore.user.is_admin) return true;
 
-    return props.movie.user?.id === authStore.user.id && props.movie.status !== MovieStatus.Watched;
+    return (
+      props.movie.user?.id === authStore.user.id &&
+      props.movie.status !== MovieStatus.Watched
+    );
   };
 
   const boobiesLabel = (boobies: boolean) =>

--- a/frontend/src/components/MovieCard.tsx
+++ b/frontend/src/components/MovieCard.tsx
@@ -11,6 +11,7 @@ interface MovieCardProps {
   movie: Movie;
   viewType?: "list" | "grid";
   onAction?: () => void;
+  isStreamed?: boolean;
 }
 
 const MovieCard: Component<MovieCardProps> = (props) => {
@@ -69,7 +70,7 @@ const MovieCard: Component<MovieCardProps> = (props) => {
 
   return (
     <div
-      class="movie-card"
+      class={`movie-card ${props.isStreamed ? "streaming-card" : ""}`}
       classList={{
         "grid-card": props.viewType === "grid",
         "boobies-movie": props.movie.boobies,

--- a/frontend/src/components/MovieCard.tsx
+++ b/frontend/src/components/MovieCard.tsx
@@ -5,6 +5,7 @@ import authStore from "@/hooks/authStore";
 import { FiEye, FiEyeOff, FiTrash } from "solid-icons/fi";
 import { TbOutlineRating18Plus } from "solid-icons/tb";
 import type { Movie } from "@/types";
+import { MovieStatus } from "@/hooks/movieStore";
 
 interface MovieCardProps {
   movie: Movie;
@@ -45,7 +46,7 @@ const MovieCard: Component<MovieCardProps> = (props) => {
     }
   };
 
-  const isWatched = () => props.movie.watched;
+  const isWatched = () => props.movie.status === MovieStatus.Watched;
 
   const canToggleWatch = () => !!authStore.user && authStore.user.is_admin;
 
@@ -53,14 +54,14 @@ const MovieCard: Component<MovieCardProps> = (props) => {
     if (!authStore.user) return false;
     if (authStore.user.is_admin) return true;
 
-    return props.movie.user?.id === authStore.user.id && !props.movie.watched;
+    return props.movie.user?.id === authStore.user.id && props.movie.status !== MovieStatus.Watched;
   };
 
   const canToggleBoobies = () => {
     if (!authStore.user) return false;
     if (authStore.user.is_admin) return true;
 
-    return props.movie.user?.id === authStore.user.id && !props.movie.watched;
+    return props.movie.user?.id === authStore.user.id && props.movie.status !== MovieStatus.Watched;
   };
 
   const boobiesLabel = (boobies: boolean) =>

--- a/frontend/src/components/MovieCard.tsx
+++ b/frontend/src/components/MovieCard.tsx
@@ -18,7 +18,7 @@ const MovieCard: Component<MovieCardProps> = (props) => {
   const [actionLoading, setActionLoading] = createSignal(false);
 
   const movieIconsClass = () =>
-    isUserAdmin() && props.viewType === "grid" ? "movie-icons-column" : "movie-icons";
+    isUserAdmin() && props.viewType === "grid" ? "movie-icons-col" : "movie-icons";
 
   const handleSetStatus = async (targetStatus: MovieStatus) => {
     setActionLoading(true);

--- a/frontend/src/components/MovieCard.tsx
+++ b/frontend/src/components/MovieCard.tsx
@@ -18,7 +18,9 @@ const MovieCard: Component<MovieCardProps> = (props) => {
   const [actionLoading, setActionLoading] = createSignal(false);
 
   const movieIconsClass = () =>
-    isUserAdmin() && props.viewType === "grid" ? "movie-icons-col" : "movie-icons";
+    isUserAdmin() && props.viewType === "grid"
+      ? "movie-icons-col"
+      : "movie-icons";
 
   const handleSetStatus = async (targetStatus: MovieStatus) => {
     setActionLoading(true);

--- a/frontend/src/components/MovieCard.tsx
+++ b/frontend/src/components/MovieCard.tsx
@@ -18,7 +18,7 @@ const MovieCard: Component<MovieCardProps> = (props) => {
   const [actionLoading, setActionLoading] = createSignal(false);
 
   const movieIconsClass = () =>
-    isUserAdmin() ? "movie-icons-column" : "movie-icons";
+    isUserAdmin() && props.viewType === "grid" ? "movie-icons-column" : "movie-icons";
 
   const handleSetStatus = async (targetStatus: MovieStatus) => {
     setActionLoading(true);

--- a/frontend/src/components/StreamingSection.tsx
+++ b/frontend/src/components/StreamingSection.tsx
@@ -1,12 +1,6 @@
-import {
-  Accessor,
-  type Component,
-  For,
-  Show,
-} from "solid-js";
+import { Accessor, type Component, For, Show } from "solid-js";
 import MovieCard from "@/components/MovieCard";
 import type { Movie } from "@/types";
-import { FaSolidVideoCamera } from "solid-icons/fa";
 
 interface StreamingSectionProps {
   movies: Accessor<Movie[]>;
@@ -20,9 +14,7 @@ const StreamingSection: Component<StreamingSectionProps> = (props) => {
 
   return (
     <section class="movie-section">
-      <h2 class="section-heading">
-        Currently streaming
-      </h2>
+      <h2 class="section-heading">Currently streaming</h2>
       <div class={gridClass()}>
         <Show
           when={props.movies().length > 0}

--- a/frontend/src/components/StreamingSection.tsx
+++ b/frontend/src/components/StreamingSection.tsx
@@ -1,0 +1,49 @@
+import {
+  Accessor,
+  type Component,
+  For,
+  Show,
+} from "solid-js";
+import MovieCard from "@/components/MovieCard";
+import type { Movie } from "@/types";
+import { FaSolidVideoCamera } from "solid-icons/fa";
+
+interface StreamingSectionProps {
+  movies: Accessor<Movie[]>;
+  viewType?: "list" | "grid";
+  onAction?: () => void;
+}
+
+const StreamingSection: Component<StreamingSectionProps> = (props) => {
+  const gridClass = () =>
+    `movie-list${props.viewType === "grid" ? " streaming-grid" : ""}`;
+
+  return (
+    <section class="movie-section">
+      <h2 class="section-heading">
+        Currently streaming
+      </h2>
+      <div class={gridClass()}>
+        <Show
+          when={props.movies().length > 0}
+          fallback={
+            <p class="empty-message">Not streaming any movies currently.</p>
+          }
+        >
+          <For each={props.movies()}>
+            {(movie) => (
+              <MovieCard
+                movie={movie}
+                viewType={props.viewType}
+                onAction={props.onAction}
+                isStreamed={true}
+              />
+            )}
+          </For>
+        </Show>
+      </div>
+    </section>
+  );
+};
+
+export default StreamingSection;

--- a/frontend/src/components/StreamingSection.tsx
+++ b/frontend/src/components/StreamingSection.tsx
@@ -4,38 +4,33 @@ import type { Movie } from "@/types";
 
 interface StreamingSectionProps {
   movies: Accessor<Movie[]>;
-  viewType?: "list" | "grid";
+  // viewType?: "list" | "grid";
   onAction?: () => void;
 }
 
-const StreamingSection: Component<StreamingSectionProps> = (props) => {
-  const gridClass = () =>
-    `movie-list${props.viewType === "grid" ? " streaming-grid" : ""}`;
-
-  return (
-    <section class="movie-section">
-      <h2 class="section-heading">Currently streaming</h2>
-      <div class={gridClass()}>
-        <Show
-          when={props.movies().length > 0}
-          fallback={
-            <p class="empty-message">Not streaming any movies currently.</p>
-          }
-        >
-          <For each={props.movies()}>
-            {(movie) => (
-              <MovieCard
-                movie={movie}
-                viewType={props.viewType}
-                onAction={props.onAction}
-                isStreamed={true}
-              />
-            )}
-          </For>
-        </Show>
-      </div>
-    </section>
-  );
-};
+const StreamingSection: Component<StreamingSectionProps> = (props) => (
+  <section class="movie-section">
+    <h2 class="section-heading">Currently streaming</h2>
+    <div class="movie-list">
+      <Show
+        when={props.movies().length > 0}
+        fallback={
+          <p class="empty-message">Not streaming any movies currently.</p>
+        }
+      >
+        <For each={props.movies()}>
+          {(movie) => (
+            <MovieCard
+              movie={movie}
+              viewType="list"
+              onAction={props.onAction}
+              isStreamed={true}
+            />
+          )}
+        </For>
+      </Show>
+    </div>
+  </section>
+);
 
 export default StreamingSection;

--- a/frontend/src/hooks/movieStore.ts
+++ b/frontend/src/hooks/movieStore.ts
@@ -5,7 +5,7 @@ import type { Movie } from "@/types";
 export enum MovieStatus {
   Watched = "watched",
   Streaming = "streaming",
-  Upcoming = "upcoming"
+  Upcoming = "upcoming",
 }
 
 interface MovieStore {

--- a/frontend/src/hooks/movieStore.ts
+++ b/frontend/src/hooks/movieStore.ts
@@ -2,6 +2,12 @@ import { createStore } from "solid-js/store";
 import { api } from "@/utils/api";
 import type { Movie } from "@/types";
 
+export enum MovieStatus {
+  Watched = "watched",
+  Streaming = "streaming",
+  Upcoming = "upcoming"
+}
+
 interface MovieStore {
   movies: Movie[];
   loading: boolean;

--- a/frontend/src/styles/movie-card.css
+++ b/frontend/src/styles/movie-card.css
@@ -33,11 +33,6 @@
   animation: streaming-pulse 6s infinite ease-in-out;
 }
 
-.streaming-grid {
-  @apply grid gap-5 p-5;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-}
-
 @keyframes streaming-pulse {
   0% {
     box-shadow: 0px 0px 20px 0px rgba(255, 0, 0, 0.25);
@@ -70,7 +65,7 @@
 }
 
 .grid-card .movie-icons-col {
-  @apply ml-0 items-center flex-column w-full justify-between;
+  @apply ml-0 items-center flex-col w-full justify-between;
 }
 
 .grid-card .movie-links {

--- a/frontend/src/styles/movie-card.css
+++ b/frontend/src/styles/movie-card.css
@@ -69,6 +69,10 @@
   @apply ml-0 items-center flex-row gap-4 w-full justify-between;
 }
 
+.grid-card .movie-icons-col {
+  @apply ml-0 items-center flex-column w-full justify-between;
+}
+
 .grid-card .movie-links {
   @apply justify-center;
 }

--- a/frontend/src/styles/movie-card.css
+++ b/frontend/src/styles/movie-card.css
@@ -28,6 +28,30 @@
   }
 }
 
+/* Streaming card */
+.streaming-card {
+  animation: streaming-pulse 6s infinite ease-in-out;
+}
+
+.streaming-grid {
+  @apply grid gap-5 p-5;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+@keyframes streaming-pulse {
+  0% {
+    box-shadow: 0px 0px 20px 0px rgba(255, 0, 0, 0.25);
+  }
+
+  50% {
+    box-shadow: 0px 0px 20px 10px rgba(255, 0, 0, 0.35);
+  }
+
+  100% {
+    box-shadow: 0px 0px 20px 0px rgba(255, 0, 0, 0.25);
+  }
+}
+
 /* Grid mode: vertical card layout */
 .grid-card {
   @apply flex-col items-center text-center;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -9,7 +9,7 @@ export interface Movie {
   rating?: string;
   votes?: string;
   no_reviews?: string;
-  watched: boolean;
+  status: "watched" | "upcoming" | "streaming";
   inserted_at?: string | null;
   boobies: boolean;
   user?: {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,4 +1,5 @@
 import type { User } from "@/hooks/authStore";
+import { MovieStatus } from "@/hooks/movieStore";
 import type { Movie } from "@/types";
 
 export const api = {
@@ -51,12 +52,14 @@ export const api = {
     return response.json();
   },
 
-  async toggleWatch(movieId: string) {
-    const response = await fetch(`/api/movies/${movieId}/toggle_watch`, {
+  async setMovieStatus(movieId: string, status: MovieStatus) {
+    const response = await fetch(`/api/movies/${movieId}/set_status`, {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
     });
     if (!response.ok) {
-      throw new Error("Failed to toggle watch status");
+      throw new Error("Failed to set movie status");
     }
     return response.json();
   },

--- a/movienite.py
+++ b/movienite.py
@@ -44,7 +44,7 @@ def fetch_imdb(url: str) -> dict | None:
             'rating': score,
             'votes': votes,
             'boobies': False,
-            'watched': False
+            'status': 'upcoming'
         }
     except:
         return None


### PR DESCRIPTION
The movie database now holds a field of type string for the movie status instead of a boolean.
Migration might break the database here... I'm not sure what will happen. God speed.

Supported statuses: Watched, Upcoming and Streaming

<img width="1184" height="341" alt="image" src="https://github.com/user-attachments/assets/87db46f1-3b2c-4355-8eab-5d84c96f2c2f" />

<img width="1190" height="1021" alt="image" src="https://github.com/user-attachments/assets/ac952715-31ec-490d-8473-fc55fd312fe2" />

<img width="1181" height="585" alt="image" src="https://github.com/user-attachments/assets/6dcf2ea1-76c7-4b9d-9e69-d17e203790a8" />
